### PR TITLE
Handle Facility w/o Latitude + Longitude

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nsastorage (1.0.1)
+    nsastorage (1.0.2)
       http
       json
       nokogiri

--- a/lib/nsastorage/facility.rb
+++ b/lib/nsastorage/facility.rb
@@ -37,7 +37,7 @@ module NSAStorage
     attr_accessor :address
 
     # @attribute [rw] geocode
-    #   @return [Geocode]
+    #   @return [Geocode, nil]
     attr_accessor :geocode
 
     # @attribute [rw] prices

--- a/lib/nsastorage/geocode.rb
+++ b/lib/nsastorage/geocode.rb
@@ -18,8 +18,10 @@ module NSAStorage
     #
     # @return [Geocode]
     def self.parse(document:)
-      latitude = LATITUDE_REGEX.match(document.text)[:latitude]
-      longitude = LONGITUDE_REGEX.match(document.text)[:longitude]
+      latitude = LATITUDE_REGEX.match(document.text)&.[](:latitude)
+      longitude = LONGITUDE_REGEX.match(document.text)&.[](:longitude)
+
+      return if latitude.nil? || longitude.nil?
 
       new(latitude: Float(latitude), longitude: Float(longitude))
     end

--- a/lib/nsastorage/version.rb
+++ b/lib/nsastorage/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NSAStorage
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end


### PR DESCRIPTION
This fixes an issue where the scraper crashes for facilities w/o a latitude or longitude (e.g. https://www.nsastorage.com/storage/alabama/storage-units-northport/8651-Charlie-Shirley-Rd-1143). For those cases facility.geocode is `nil`. 